### PR TITLE
Add batching to equipment list population for large item count

### DIFF
--- a/src/Retinues/GUI/Editor/VM/Equipment/List/EquipmentList.cs
+++ b/src/Retinues/GUI/Editor/VM/Equipment/List/EquipmentList.cs
@@ -145,10 +145,11 @@ namespace Retinues.GUI.Editor.VM.Equipment.List
             {
                 await Task.Yield();
 
-                var batchSize = 50;
                 var batchSize = 64;
-                var allItems = await Task.Run(() =>
-                    EquipmentManager.CollectAvailableItems(State.Faction, State.Slot, cache: cache)
+                var allItems = EquipmentManager.CollectAvailableItems(
+                    State.Faction,
+                    State.Slot,
+                    cache: cache
                 );
 
                 // Clear existing rows
@@ -180,7 +181,7 @@ namespace Retinues.GUI.Editor.VM.Equipment.List
 
                         if (batch.Count >= batchSize)
                         {
-                            await Task.Delay(1);
+                            await Task.Yield();
 
                             if (_needsRebuild || !IsVisible || _lastSlotId != slotId)
                                 return;
@@ -192,7 +193,7 @@ namespace Retinues.GUI.Editor.VM.Equipment.List
                         }
                     }
 
-                    await Task.Delay(1);
+                    await Task.Yield();
                     if (_needsRebuild || !IsVisible || _lastSlotId != slotId)
                         return;
 


### PR DESCRIPTION
Adds batching when populating equipment rows to prevent UI stalls on large sets.

This fixes crashing when the equipment list exceeds ~1500 items. In my case with "All Equipment Unlocked" enabled there are about 1900 helmets which caused a crash without batching.

Note: this is a targeted fix. A deeper rework of the list population architecture could likely handle this more cleanly.