### PR TITLE
Optimize slot and equipment row event handling

### DIFF
--- a/src/Retinues/GUI/Editor/BaseButtonVM.cs
+++ b/src/Retinues/GUI/Editor/BaseButtonVM.cs
@@ -18,6 +18,12 @@ namespace Retinues.GUI.Editor
         public abstract bool IsEnabled { get; }
 
         /// <summary>
+        /// Allow subclasses to opt out of global event registration.
+        /// </summary>
+        protected BaseButtonVM(bool autoRegister = true)
+            : base(autoRegister) { }
+
+        /// <summary>
         /// Whether the button is currently selected.
         /// </summary>
         [DataSourceProperty]

--- a/src/Retinues/GUI/Editor/BaseListElementVM.cs
+++ b/src/Retinues/GUI/Editor/BaseListElementVM.cs
@@ -21,6 +21,12 @@ namespace Retinues.GUI.Editor
         }
 
         /// <summary>
+        /// Allow subclasses to opt out of global event registration.
+        /// </summary>
+        protected BaseListElementVM(bool autoRegister = true)
+            : base(autoRegister) { }
+
+        /// <summary>
         /// Determine whether this element matches the provided filter.
         /// </summary>
         public abstract bool FilterMatch(string filter);

--- a/src/Retinues/GUI/Editor/BaseVM.cs
+++ b/src/Retinues/GUI/Editor/BaseVM.cs
@@ -50,7 +50,14 @@ namespace Retinues.GUI.Editor
         private bool _queuedWhileHidden;
         private bool _inPulse;
 
-        protected BaseVM() => EventManager.Register(this);
+        /// <summary>
+        /// Base constructor with optional automatic event registration.
+        /// </summary>
+        protected BaseVM(bool autoRegister = true)
+        {
+            if (autoRegister)
+                EventManager.Register(this);
+        }
 
         ~BaseVM() => EventManager.Unregister(this);
 
@@ -96,6 +103,8 @@ namespace Retinues.GUI.Editor
                 OnEquipmentChange();
             else if (e == UIEvent.Slot)
                 OnSlotChange();
+            else if (e == UIEvent.Equip)
+                OnEquipChange();
 
             // If hidden and not opted-in, don't execute heavy hooks—just queue.
             if (!IsVisible)
@@ -162,6 +171,11 @@ namespace Retinues.GUI.Editor
         /// Called when the selected equipment slot changed.
         /// </summary>
         protected virtual void OnSlotChange() { }
+
+        /// <summary>
+        /// Called when equip-related data changed.
+        /// </summary>
+        protected virtual void OnEquipChange() { }
 
         // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ //
         //                         Input                          //

--- a/src/Retinues/GUI/Editor/VM/Equipment/EquipmentScreen.cs
+++ b/src/Retinues/GUI/Editor/VM/Equipment/EquipmentScreen.cs
@@ -124,6 +124,10 @@ namespace Retinues.GUI.Editor.VM.Equipment
         //                         Helpers                        //
         // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ //
 
+        private readonly Dictionary<EquipmentIndex, EquipmentSlotVM> _slotsByIndex;
+
+        private EquipmentIndex? _lastSlotIndex = State.Slot;
+
         private IEnumerable<EquipmentSlotVM> EquipmentSlots =>
             [
                 Weapon1Slot,
@@ -138,6 +142,33 @@ namespace Retinues.GUI.Editor.VM.Equipment
                 HorseSlot,
                 HorseHarnessSlot,
             ];
+
+        /// <summary>
+        /// Initialize the equipment screen and index slot view-models by equipment slot.
+        /// </summary>
+        public EquipmentScreenVM()
+        {
+            _slotsByIndex = new Dictionary<EquipmentIndex, EquipmentSlotVM>(13)
+            {
+                [EquipmentIndex.Weapon0] = Weapon1Slot,
+                [EquipmentIndex.Weapon1] = Weapon2Slot,
+                [EquipmentIndex.Weapon2] = Weapon3Slot,
+                [EquipmentIndex.Weapon3] = Weapon4Slot,
+                [EquipmentIndex.Head] = HeadSlot,
+                [EquipmentIndex.Cape] = CapeSlot,
+                [EquipmentIndex.Body] = BodySlot,
+                [EquipmentIndex.Gloves] = GlovesSlot,
+                [EquipmentIndex.Leg] = LegSlot,
+                [EquipmentIndex.Horse] = HorseSlot,
+                [EquipmentIndex.HorseHarness] = HorseHarnessSlot,
+            };
+        }
+
+        /// <summary>
+        /// Lookup helper for slot view-models by equipment index.
+        /// </summary>
+        private EquipmentSlotVM GetSlotVm(EquipmentIndex index) =>
+            _slotsByIndex.TryGetValue(index, out var vm) ? vm : null;
 
         // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ //
         //                      Data Bindings                     //
@@ -217,6 +248,31 @@ namespace Retinues.GUI.Editor.VM.Equipment
                 State.Equipment.Index,
                 BattleType.SiegeAssault
             );
+
+        /// <summary>
+        /// Handle slot selection changes and update the affected slot buttons.
+        /// </summary>
+        protected override void OnSlotChange()
+        {
+            var previous = _lastSlotIndex;
+            var current = State.Slot;
+
+            if (previous.HasValue && previous.Value != current)
+                GetSlotVm(previous.Value)?.OnSlotChanged();
+
+            GetSlotVm(current)?.OnSlotChanged();
+            _lastSlotIndex = current;
+        }
+
+        /// <summary>
+        /// Handle equipment loadout changes for the current slot button.
+        /// </summary>
+        protected override void OnEquipmentChange() => GetSlotVm(State.Slot)?.OnEquipmentChanged();
+
+        /// <summary>
+        /// Handle staged equip changes for the current slot button.
+        /// </summary>
+        protected override void OnEquipChange() => GetSlotVm(State.Slot)?.OnEquipChanged();
 
         /* ━━━━━━━ Tooltips ━━━━━━━ */
 

--- a/src/Retinues/GUI/Editor/VM/Equipment/List/EquipmentRow.cs
+++ b/src/Retinues/GUI/Editor/VM/Equipment/List/EquipmentRow.cs
@@ -25,7 +25,7 @@ namespace Retinues.GUI.Editor.VM.Equipment.List
         bool isAvailable,
         bool isUnlocked,
         int progress
-    ) : BaseListElementVM
+    ) : BaseListElementVM(autoRegister: false)
     {
         // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ //
         //                         Fields                         //
@@ -509,6 +509,45 @@ namespace Retinues.GUI.Editor.VM.Equipment.List
                 || category.Contains(search)
                 || type.Contains(search)
                 || culture.Contains(search);
+        }
+
+        /// <summary>
+        /// Refresh slot-related bindings when the active slot changes.
+        /// </summary>
+        public void OnSlotChanged()
+        {
+            OnPropertyChanged(nameof(IsSelected));
+            OnPropertyChanged(nameof(ShowIsEquipped));
+            OnPropertyChanged(nameof(ShowInStockText));
+            OnPropertyChanged(nameof(ShowValue));
+        }
+
+        /// <summary>
+        /// Refresh bindings affected by staged equip updates.
+        /// </summary>
+        public void OnEquipChanged()
+        {
+            OnPropertyChanged(nameof(IsSelected));
+            OnPropertyChanged(nameof(Stock));
+            OnPropertyChanged(nameof(InStockText));
+            OnPropertyChanged(nameof(ShowInStockText));
+            OnPropertyChanged(nameof(ShowValue));
+            OnPropertyChanged(nameof(ShowIsEquipped));
+            OnPropertyChanged(nameof(IsDisabledText));
+        }
+
+        /// <summary>
+        /// Refresh bindings affected by equipment loadout changes.
+        /// </summary>
+        public void OnEquipmentChanged()
+        {
+            OnPropertyChanged(nameof(IsSelected));
+            OnPropertyChanged(nameof(IsEnabled));
+            OnPropertyChanged(nameof(Stock));
+            OnPropertyChanged(nameof(ShowIsEquipped));
+            OnPropertyChanged(nameof(IsDisabledText));
+            OnPropertyChanged(nameof(ShowInStockText));
+            OnPropertyChanged(nameof(ShowValue));
         }
     }
 }

--- a/src/Retinues/GUI/Editor/VM/Equipment/Panel/EquipmentSlot.cs
+++ b/src/Retinues/GUI/Editor/VM/Equipment/Panel/EquipmentSlot.cs
@@ -15,7 +15,7 @@ namespace Retinues.GUI.Editor.VM.Equipment.Panel
     /// ViewModel for a single equipment slot, presenting item data and actions.
     /// </summary>
     [SafeClass]
-    public sealed class EquipmentSlotVM(EquipmentIndex index) : BaseButtonVM
+    public sealed class EquipmentSlotVM(EquipmentIndex index) : BaseButtonVM(autoRegister: false)
     {
         // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ //
         //                         Fields                         //
@@ -184,5 +184,44 @@ namespace Retinues.GUI.Editor.VM.Equipment.Panel
         /// Select this equipment slot for editing.
         /// </summary>
         public void ExecuteSelect() => State.UpdateSlot(Index);
+
+        /// <summary>
+        /// The equipment index represented by this slot button.
+        /// </summary>
+        public EquipmentIndex SlotIndex => Index;
+
+        // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ //
+        //                        Refreshers                     //
+        // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ //
+
+        /// <summary>
+        /// Refresh selection state when the active slot changes.
+        /// </summary>
+        public void OnSlotChanged() => OnPropertyChanged(nameof(IsSelected));
+
+        /// <summary>
+        /// Refresh all equipment-dependent bindings for this slot.
+        /// </summary>
+        public void OnEquipmentChanged()
+        {
+            OnPropertyChanged(nameof(ItemText));
+            OnPropertyChanged(nameof(ItemTextColor));
+            OnPropertyChanged(nameof(IsStaged));
+            OnPropertyChanged(nameof(ImageId));
+            OnPropertyChanged(nameof(ImageAdditionalArgs));
+#if BL13
+            OnPropertyChanged(nameof(ImageTextureProviderName));
+#else
+            OnPropertyChanged(nameof(ImageTypeCode));
+#endif
+            OnPropertyChanged(nameof(Hint));
+            OnPropertyChanged(nameof(EquipChangeHint));
+            OnPropertyChanged(nameof(IsEnabled));
+        }
+
+        /// <summary>
+        /// Refresh staged equip indicators for this slot.
+        /// </summary>
+        public void OnEquipChanged() => OnEquipmentChanged();
     }
 }


### PR DESCRIPTION
Opt equipment slots and troop rows out of automatic global event registration. Any event would be sent to possibly 1000 equipment rows which causes stutter. 

Slightly reduces the initial stutter when clicking on a new slot when high row count.

+ Now only the affected rows in Equip will update, which practically removes the stutter entirely when equipping a new item. In my case, when equipping a new item, the game will stutter for a few second, now it does not.

Other VMs could take advantage of this as well.

Let me know if im missing something or whatever issues may arise. I do want to learn more about Bannerlord modding.