### PR TITLE
Remove redundant updates in ResetAll

### DIFF
--- a/src/Retinues/GUI/Editor/State.cs
+++ b/src/Retinues/GUI/Editor/State.cs
@@ -93,12 +93,6 @@ namespace Retinues.GUI.Editor
             EventManager.FireBatch(() =>
             {
                 UpdateFaction();
-                UpdateTroop();
-                UpdateEquipment();
-                UpdateSlot();
-                UpdateEquipData();
-                UpdateSkillData();
-                UpdateConversionData();
                 UpdatePartyData();
             });
         }


### PR DESCRIPTION
UpdateFaction() already calls UpdateTroop() which already calls UpdateEquipment() which calls UpdateEquipData(), UpdateSlot(), UpdateSkillData(), and UpdateConversionData()