### PR TITLE
Optimize + Fix + Improve => Troop Matching and Conversions

### DIFF
--- a/src/Retinues/GUI/Editor/BaseVM.cs
+++ b/src/Retinues/GUI/Editor/BaseVM.cs
@@ -111,6 +111,8 @@ namespace Retinues.GUI.Editor
                 OnSlotChange();
             else if (e == UIEvent.Equip)
                 OnEquipChange();
+            else if (e == UIEvent.Conversion)
+                OnConversionChange();
 
             // If hidden and not opted-in, queue for later
             if (!IsVisible)
@@ -182,6 +184,11 @@ namespace Retinues.GUI.Editor
         /// Called when equip-related data changed.
         /// </summary>
         protected virtual void OnEquipChange() { }
+
+        /// <summary>
+        /// Called when conversion-related data changed.
+        /// </summary>
+        protected virtual void OnConversionChange() { }
 
         // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ //
         //                         Input                          //

--- a/src/Retinues/GUI/Editor/State.cs
+++ b/src/Retinues/GUI/Editor/State.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Retinues.Features.Upgrade.Behaviors;
 using Retinues.Game;
+using Retinues.Game.Helpers;
 using Retinues.Game.Wrappers;
 using Retinues.Troops;
 using Retinues.Troops.Edition;
@@ -124,6 +125,8 @@ namespace Retinues.GUI.Editor
         public static void UpdateTroop(WCharacter troop = null)
         {
             troop ??= Faction.Troops.FirstOrDefault();
+            if (Troop != null && Troop.StringId == troop?.StringId)
+                return;
 
             EventManager.FireBatch(() =>
             {
@@ -131,7 +134,6 @@ namespace Retinues.GUI.Editor
 
                 UpdateEquipment();
                 UpdateSkillData();
-                UpdateConversionData();
                 UpdateSlot();
 
                 EventManager.Fire(UIEvent.Troop);
@@ -171,6 +173,23 @@ namespace Retinues.GUI.Editor
         {
             EquipData = ComputeEquipData();
 
+            if (
+                singleUpdate
+                && (
+                    Slot == EquipmentIndex.Weapon0
+                    || Slot == EquipmentIndex.Weapon1
+                    || Slot == EquipmentIndex.Weapon2
+                    || Slot == EquipmentIndex.Weapon3
+                    || Slot == EquipmentIndex.Horse
+                )
+            )
+            {
+                TroopMatcher.InvalidateTroopCache(Troop);
+            }
+
+            if (Troop?.IsRetinue == true)
+                UpdateConversionData();
+
             if (singleUpdate)
             {
                 LastEquipChange = CaptureEquipChange(EquipData, Slot);
@@ -200,6 +219,31 @@ namespace Retinues.GUI.Editor
 
             ConversionData = conversionData;
             EventManager.Fire(UIEvent.Conversion);
+        }
+
+        /// <summary>
+        /// Clear staged conversion selections without recomputing data.
+        /// </summary>
+        public static void ClearPendingConversions()
+        {
+            if (ConversionData == null)
+            {
+                UpdateConversionData();
+                return;
+            }
+
+            bool changed = false;
+            foreach (var key in ConversionData.Keys.ToList())
+            {
+                if (ConversionData[key] == 0)
+                    continue;
+
+                ConversionData[key] = 0;
+                changed = true;
+            }
+
+            if (changed)
+                EventManager.Fire(UIEvent.Conversion);
         }
 
         /// <summary>
@@ -266,11 +310,12 @@ namespace Retinues.GUI.Editor
         {
             var data = new Dictionary<WCharacter, int>();
 
-            if (Troop?.IsRetinue == false)
+            if (Troop?.IsRetinue != true)
                 return data;
 
             foreach (var source in TroopManager.GetRetinueSourceTroops(Troop))
-                data[source] = 0;
+                if (source?.IsValid == true)
+                    data[source] = 0;
 
             return data;
         }

--- a/src/Retinues/GUI/Editor/VM/Editor.cs
+++ b/src/Retinues/GUI/Editor/VM/Editor.cs
@@ -50,6 +50,9 @@ namespace Retinues.GUI.Editor.VM
         /// </summary>
         public void SwitchScreen(Screen value)
         {
+            if (Screen == value && IsVisible)
+                return;
+
             Log.Info($"Switching screen from {Screen} to {value}");
 
             Screen = value;
@@ -137,7 +140,8 @@ namespace Retinues.GUI.Editor.VM
         /* ━━━━━━━━━ Flags ━━━━━━━━ */
 
         [DataSourceProperty]
-        public bool ShowFactionButton => Screen != Screen.Doctrine && Player.Kingdom != null && !Config.NoKingdomTroops;
+        public bool ShowFactionButton =>
+            Screen != Screen.Doctrine && Player.Kingdom != null && !Config.NoKingdomTroops;
 
         [DataSourceProperty]
         public bool ShowDoctrinesButton =>

--- a/src/Retinues/Troops/Edition/TroopManager.cs
+++ b/src/Retinues/Troops/Edition/TroopManager.cs
@@ -197,8 +197,16 @@ namespace Retinues.Troops.Edition
                 factionRoot = retinue.Faction?.RootBasic;
             }
 
+            // Precompute troop weapons and skills data
+            var (weapons, skills) = TroopMatcher.GetTroopClassesSkills(retinue);
+
             // Culture pick
-            var culturePick = TroopMatcher.PickBestFromTree(cultureRoot, retinue);
+            var culturePick = TroopMatcher.PickBestFromTree(
+                cultureRoot,
+                retinue,
+                troopWeapons: weapons,
+                troopSkills: skills
+            );
             if (culturePick?.IsValid == true)
                 sources.Add(culturePick);
 
@@ -206,7 +214,9 @@ namespace Retinues.Troops.Edition
             var factionPick = TroopMatcher.PickBestFromTree(
                 factionRoot,
                 retinue,
-                exclude: culturePick
+                exclude: culturePick,
+                troopWeapons: weapons,
+                troopSkills: skills
             );
             if (factionPick?.IsValid == true)
                 sources.Add(factionPick);


### PR DESCRIPTION
Retinue and regular-to-custom matches now cache their results, so we skip recomputing the “closest” pick on every lookup.

Equip updates to weapons and horse slots invalidate the appropriate cache. Any non-retinue custom troop edit flushes the regular-to-custom cache so a new best match can be appropriately matched later.

Troop panel listens for conversion change events and only rebuilds when needed.

Fixed an issue where retinue conversion rows would not update until switching to a different troop and switching back, due to the UI not receiving conversion events.

Clicking on the same troop no longer calls for updates.

PickBestFromTree now uses a for loop instead of a chained LINQ expression for better performance.

Matching reuses precomputed weapon/skill data across tree scans, so the selection pass runs faster without re-parsing troop weapon/skill data.

Added ClearPendingConversions so the UI can wipe staged conversions without recomputing the whole dataset

**do test thoroughly** (**left in logging for testing**) 😃