### PR TITLE
Allow players to change the Race of Troops

### DIFF
--- a/loc/Retinues/Languages/ret_strings.xml
+++ b/loc/Retinues/Languages/ret_strings.xml
@@ -125,6 +125,9 @@
       id="ret_change_culture_title"
       text="Change Culture" />
     <string
+      id="ret_change_race_title"
+      text="Change Race" />
+    <string
       id="ret_clanic_traditions"
       text="Clan Traditions" />
     <string
@@ -776,6 +779,12 @@
       id="ret_no_cultures_title"
       text="No Cultures Found" />
     <string
+      id="ret_no_races_text"
+      text="No alternative races are available." />
+    <string
+      id="ret_no_races_title"
+      text="No Races Found" />
+    <string
       id="ret_no_skill_points_left"
       text="No skill points left for this troop." />
     <string
@@ -832,6 +841,9 @@
     <string
       id="ret_queen_guard"
       text="Queen&apos;s Guard" />
+    <string
+      id="ret_race_header_text"
+      text="Race" />
     <string
       id="ret_rank_up"
       text="Rank Up" />

--- a/loc/Retinues/strings.json
+++ b/loc/Retinues/strings.json
@@ -640,6 +640,22 @@
     "TR": "Kültürü Değiştir"
   },
   {
+    "id": "ret_change_race_title",
+    "EN": "Change Race",
+    "BR": null,
+    "CNs": null,
+    "CNt": null,
+    "DE": null,
+    "FR": null,
+    "IT": null,
+    "JP": null,
+    "KO": null,
+    "PL": null,
+    "RU": null,
+    "SP": null,
+    "TR": null
+  },
+  {
     "id": "ret_clanic_traditions",
     "EN": "Clan Traditions",
     "BR": "Tradições do Clã",
@@ -4112,6 +4128,38 @@
     "TR": "Kültür Bulunamadı"
   },
   {
+    "id": "ret_no_races_text",
+    "EN": "No alternative races are available.",
+    "BR": null,
+    "CNs": null,
+    "CNt": null,
+    "DE": null,
+    "FR": null,
+    "IT": null,
+    "JP": null,
+    "KO": null,
+    "PL": null,
+    "RU": null,
+    "SP": null,
+    "TR": null
+  },
+  {
+    "id": "ret_no_races_title",
+    "EN": "No Races Found",
+    "BR": null,
+    "CNs": null,
+    "CNt": null,
+    "DE": null,
+    "FR": null,
+    "IT": null,
+    "JP": null,
+    "KO": null,
+    "PL": null,
+    "RU": null,
+    "SP": null,
+    "TR": null
+  },
+  {
     "id": "ret_no_skill_points_left",
     "EN": "No skill points left for this troop.",
     "BR": "Nenhum ponto de habilidade restante para esta tropa.",
@@ -4414,6 +4462,22 @@
     "RU": "Гвардия Королевы",
     "SP": "Guardia de la Reina",
     "TR": "Kraliçenin Muhafızları"
+  },
+  {
+    "id": "ret_race_header_text",
+    "EN": "Race",
+    "BR": null,
+    "CNs": null,
+    "CNt": null,
+    "DE": null,
+    "FR": null,
+    "IT": null,
+    "JP": null,
+    "KO": null,
+    "PL": null,
+    "RU": null,
+    "SP": null,
+    "TR": null
   },
   {
     "id": "ret_rank_up",

--- a/src/Retinues/Troops/Save/TroopSaveData.cs
+++ b/src/Retinues/Troops/Save/TroopSaveData.cs
@@ -67,5 +67,8 @@ namespace Retinues.Troops.Save
 
         [SaveableField(19)]
         public float HeightMax;
+
+        [SaveableField(20)]
+        public int Race = 0;
     }
 }

--- a/src/Retinues/Troops/TroopLoader.cs
+++ b/src/Retinues/Troops/TroopLoader.cs
@@ -110,6 +110,12 @@ namespace Retinues.Troops
                 }
             }
 
+            if (data.Race >= 0)
+            {
+                troop.Race = data.Race;
+                troop.EnsureOwnBodyRange();
+            }
+
             if (Config.EnableTroopCustomization)
             {
                 // Set dynamic properties (already handles nulls)
@@ -160,6 +166,7 @@ namespace Retinues.Troops
                 BuildMax = character.BuildMax,
                 HeightMin = character.HeightMin,
                 HeightMax = character.HeightMax,
+                Race = character.Race,
             };
 
             return data;

--- a/tpl/Retinues/partials/editor/troop/panel.sbn
+++ b/tpl/Retinues/partials/editor/troop/panel.sbn
@@ -9,7 +9,7 @@
         <!-- Troop name section (editable name fields) -->
         {{ include "editor/troop/sections/name.sbn" }}
 
-        <!-- Gender selection section (male/female toggle) -->
+        <!-- Culture / Race selection section -->
         {{ include "editor/troop/sections/culture.sbn" }}
 
         <!-- Skills section (skill sliders/values) -->

--- a/tpl/Retinues/partials/editor/troop/sections/culture.sbn
+++ b/tpl/Retinues/partials/editor/troop/sections/culture.sbn
@@ -1,19 +1,64 @@
-<!-- Section header -->
-{{ header("@CultureHeaderText") }}
-
-<!-- Gender display and change action -->
 <ListPanel
     WidthSizePolicy="CoverChildren"
     HeightSizePolicy="CoverChildren"
-    HorizontalAlignment="Center"
     StackLayout.LayoutMethod="HorizontalLeftToRight"
     UpdateChildrenStates="true"
-    MarginBottom="0">
+    MarginTop="8"
+    HorizontalAlignment="Center">
     <Children>
-        <!-- Display current culture text -->
-        {{ text("@CultureText", "Clan.RightPanel.Name.Text", "Center", "0", "0", "0", "0") }}
+        <ListPanel
+            WidthSizePolicy="CoverChildren"
+            HeightSizePolicy="CoverChildren"
+            StackLayout.LayoutMethod="VerticalTopToBottom"
+            UpdateChildrenStates="true"
+            HorizontalAlignment="Center" >
+            <Children>
+                <ListPanel
+                    WidthSizePolicy="CoverChildren"
+                    HeightSizePolicy="CoverChildren"
+                    HorizontalAlignment="Center"
+                    StackLayout.LayoutMethod="HorizontalLeftToRight"
+                    UpdateChildrenStates="true"
+                    MarginBottom="2">
+                    <Children>
+                        {{ text("@CultureText", "Clan.RightPanel.Name.Text", "Left", "10", "2", "0", "0") }}
+                        {{ button_icon("ExecuteChangeCulture", "SPClan.Parties.ChangePartyLeaderIcon", "32", "true", "true", "0", "0", "0", "0") }}
+                    </Children>
+                </ListPanel>
 
-        <!-- Button to toggle/change culture (icon) -->
-        {{ button_icon("ExecuteChangeCulture", "SPClan.Parties.ChangePartyLeaderIcon", "40", "true", "true", "0", "0", "8", "0") }}
+
+                {{ header("@CultureHeaderText") }}
+            </Children>
+        </ListPanel>
+
+        <BrushWidget
+            WidthSizePolicy="Fixed"
+            HeightSizePolicy="Fixed"
+            SuggestedWidth="25"
+            Brush="Inventory.Tuple.TupleDivider.Vertical"/>
+
+        <ListPanel
+            WidthSizePolicy="CoverChildren"
+            HeightSizePolicy="CoverChildren"
+            StackLayout.LayoutMethod="VerticalTopToBottom"
+            UpdateChildrenStates="true"
+            HorizontalAlignment="Center">
+            <Children>
+                <ListPanel
+                    WidthSizePolicy="CoverChildren"
+                    HeightSizePolicy="CoverChildren"
+                    HorizontalAlignment="Center"
+                    StackLayout.LayoutMethod="HorizontalLeftToRight"
+                    UpdateChildrenStates="true"
+                    MarginBottom="2">
+                    <Children>
+                        {{ text("@RaceText", "Clan.RightPanel.Name.Text", "Left", "10", "2", "0", "0") }}
+                        {{ button_icon("ExecuteChangeRace", "SPClan.Parties.ChangePartyLeaderIcon", "32", "@CanChangeRace", "@CanChangeRace", "0", "0", "0", "0") }}
+                    </Children>
+                </ListPanel>
+
+                {{ header("@RaceHeaderText") }}
+            </Children>
+        </ListPanel>
     </Children>
 </ListPanel>


### PR DESCRIPTION
Puts a button next to Culture that changes the race/monster/species of the troops if they have mods that add humanoid monsters.

Currently the button and "Race" header show regardless of if they have available alternate races, but I left this so it shows that the feature is available rather than it being a hidden thing.

I couldn't figure out how to get the panel to be perfectly centered, if you want to get it more centered then please :). When switching to a race with a long name, itll push the Culture side out of the way rather than moving over to be perfectly centered.

I also left the translations null since I do not know what translator you use.

Races I tested with are from The Old Realms. Not exactly on The Old Realms, but just the races. The Old Realms uses id names for the races like large_humanoid_monster or something like that, so I added a function that will format it into Large Humanoid.

---

<img width="2560" height="1440" alt="Screenshot_20251101_214428" src="https://github.com/user-attachments/assets/694b5887-1a68-49cf-b39c-946cf357791c" />
Blacked out when no alternative races are available

---

<img width="2560" height="1440" alt="Screenshot_20251101_222031" src="https://github.com/user-attachments/assets/718ee61e-bcd5-4ab1-9e56-8f11c1f5b633" />
Skeleton troop in Clan Troop Menu

---

<img width="2560" height="1440" alt="Screenshot_20251101_221421" src="https://github.com/user-attachments/assets/a6d695b1-2c9a-42cc-a5f9-8b3fef6087fd" />
Skeleton troop in Party Menu