### PR TITLE
Fix #15. Update SandBox DLL name to properly match cases.

### DIFF
--- a/src/Retinues/Retinues.csproj
+++ b/src/Retinues/Retinues.csproj
@@ -85,13 +85,13 @@
       <HintPath>$(ReferenceRoot)/TaleWorlds.SaveSystem.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <!-- Sandbox -->
-    <Reference Include="Sandbox">
-      <HintPath>$(ReferenceRoot)/Sandbox.dll</HintPath>
+    <!-- SandBox -->
+    <Reference Include="SandBox">
+      <HintPath>$(ReferenceRoot)/SandBox.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Sandbox.GauntletUI">
-      <HintPath>$(ReferenceRoot)/Sandbox.GauntletUI.dll</HintPath>
+    <Reference Include="SandBox.GauntletUI">
+      <HintPath>$(ReferenceRoot)/SandBox.GauntletUI.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <!-- UIExtenderEx -->


### PR DESCRIPTION
I am on Linux where the names are case sensitive, so the B not being capitalized caused my compile error in #15.