### PR TITLE
Fixes issue with Elite Retinue Rank-Up in Warlord's Battlefield

### DIFF
--- a/src/Retinues/GUI/Editor/VM/Troop/Panel/TroopPanel.cs
+++ b/src/Retinues/GUI/Editor/VM/Troop/Panel/TroopPanel.cs
@@ -631,7 +631,10 @@ namespace Retinues.GUI.Editor.VM.Troop.Panel
                     )
                 );
             }
-            else if (!State.Troop.IsElite && State.Troop.Tier >= State.Faction.RetinueElite.Tier)
+            else if (
+                State.Troop == State.Faction.RetinueBasic
+                && State.Troop.Tier >= State.Faction.RetinueElite.Tier
+            )
             {
                 Popup.Display(
                     L.T("rank_up_cant_outrank_elite_title", "Cannot Outrank Elite"),


### PR DESCRIPTION
Not sure what the actual cause/reason is but in Warlord's Battlefield, the elite retinue couldn't be ranked up and gave the popup saying that House Champion cannot outrank House Champion. This changes the check to only consider the basic retinue, as the elite retinue doesn't need to be checked regardless.